### PR TITLE
fix: LasVegas Sandstorm image --> renamed

### DIFF
--- a/src/common/sdk/finals-tracker/models/GameStatsResponse.ts
+++ b/src/common/sdk/finals-tracker/models/GameStatsResponse.ts
@@ -53,7 +53,7 @@ export enum RoundMap {
 
     LAS_VEGAS_BASE = "DA_MV_LasVegas_01_Base",
     LAS_VEGAS_LOCKDOWN ="DA_MV_LasVegas_01_Lockdown",
-    LAS_VEGAS_SANDSTORM = "DA_MV_LasVegas_01_SandStorm",
+    LAS_VEGAS_SANDSTORM = "DA_MV_LasVegas_01_Sandstorm",
 }
 
 export interface TournamentRound {


### PR DESCRIPTION
I've just changed the name so that the image appears on the page, even though it's the same one.
![image](https://github.com/Swackles/the-finals-tracker/assets/87929402/f7179dec-ab49-417c-b595-8fd35ae51535)
![image](https://github.com/Swackles/the-finals-tracker/assets/87929402/65e06a03-b217-44a2-a7fc-88e2ed86617b)
